### PR TITLE
Don't show outline view when setting is disabled

### DIFF
--- a/lib/impl/outline.dart
+++ b/lib/impl/outline.dart
@@ -36,7 +36,9 @@ class OutlineController extends DockedViewManager<OutlineView> {
     );
 
     disposables.add(atom.config.observe(_keyPath, null, (val) {
-      showView();
+      if (val == true) {
+        showView();
+      }
     }));
 
     disposables.add(atom.workspace.observeActiveTextEditor((activeEditor) {


### PR DESCRIPTION
The outline view was opening at startup regardless of the setting "Show outline view". It opened at every atom startup. I had to disable the `dart` plugin for the times I'm not working with dart because it's so annoying.

fixes #1164