### PR TITLE
Add "extension" keyword to gramma

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -206,7 +206,7 @@
         'name': 'keyword.control.new.dart'
       }
       {
-        'match': '(?<!\\$)\\b(abstract|class|enum|extends|external|factory|implements|get|mixin|native|operator|set|typedef|with|covariant)\\b(?!\\$)'
+        'match': '(?<!\\$)\\b(abstract|class|enum|extends|extension|external|factory|implements|get|mixin|native|operator|set|typedef|with|covariant)\\b(?!\\$)'
         'name': 'keyword.declaration.dart'
       }
       {


### PR DESCRIPTION
Related to https://github.com/dart-atom/dart/issues/1193

This is the same change made in VS Code:

https://github.com/Dart-Code/Dart-Code/commit/06eaf66e9613b16e1401dd267c5597dff1524239

Note: I don't know how to run this locally to test, I made the change blind since it seems simple and mirrors VS Code's (which I did test) :-)